### PR TITLE
HYEONMIN JO : BOJ 11068 S5 회문인 수

### DIFF
--- a/Hyeonmin/src/week15/BOJ_11068_S5_회문인수/BOJ_11068_S5_회문인수.java
+++ b/Hyeonmin/src/week15/BOJ_11068_S5_회문인수/BOJ_11068_S5_회문인수.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 
 public class BOJ_11068_S5_회문인수 {
+	
 	static int T, tgt;
 	static boolean correct;
 	


### PR DESCRIPTION
[문제풀이]
각 케이스에 해당하는 숫자를 2~64진법으로 변환후에 맨 앞, 맨 뒤에서 부터 일치하는 지 비교하여 풀었습니다.

B 진법으로 변환은 해당 진법으로 변환을 했을 때 자릿수를 구한 후에 그 길이만큼 int 배열을 만들어서 하나의 int 값에 해당 자리에 해당하는 B진법 값을 10진수로 저장한 다음에 비교를 했습니다.

[결과]
메모리 : 12192 KB 시간 : 96 ms